### PR TITLE
Add an installer for the callvlc script

### DIFF
--- a/misc_scripts/callvlc-installer/README.md
+++ b/misc_scripts/callvlc-installer/README.md
@@ -1,0 +1,13 @@
+# Installer for `callvlc`
+During the contest, the CDS publishes webcam and desktop video feeds. VLC
+identifies this feed as *H264 - MPEG-4 AVC (part 10)*, which Firefox can't
+decode. Hence, we have created a solution for opening VLC when clicking
+a video stream link. During WF 2019, these streams are served over HTTP
+without authentication.
+
+## Installation
+1. Install the Ubuntu packages `docker.io` and `docker-compose` on some
+master computer.
+2. Execute `docker-compose up` in this directory.
+3. Note the IP address of the machine. Let's say that it's `192.168.2.66`.
+4. On each machine, run `wget -O - 192.168.2.66 | sh`.

--- a/misc_scripts/callvlc-installer/docker-compose.yml
+++ b/misc_scripts/callvlc-installer/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  web:
+    image: 'nginx'
+    volumes:
+      - ./web-static/:/usr/share/nginx/html/:ro
+    ports:
+      - '80:80'

--- a/misc_scripts/callvlc-installer/web-static/index.html
+++ b/misc_scripts/callvlc-installer/web-static/index.html
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+# This script was created during WF 2019 to set up all the necessary settings
+# to allow Firefox to open VLC from iCat and connect to a team webcam or
+# desktop stream.
+
+# Create script for starting VLC
+sudo /bin/sh <<"EOF"
+printf '%s\n' '#!/usr/bin/env bash
+exec vlc ${1/vlc:\/\//http:\/\/}' > /usr/local/bin/callvlc
+chmod +x /usr/local/bin/callvlc
+EOF
+cd -- ~/.mozilla/firefox/*.default/
+
+# Create a Firefox handler for vlc://
+umask 0077
+printf '%s' '{"defaultHandlersVersion":{"en-US":4},"mimeTypes":{"application/pdf":{"action":3,"extensions":["pdf"]}},"schemes":{"ircs":{"action":2,"ask":true,"handlers":[null,{"name":"Mibbit","uriTemplate":"https://www.mibbit.com/?url=%s"}]},"mailto":{"action":2,"ask":true,"handlers":[null,{"name":"Yahoo! Mail","uriTemplate":"https://compose.mail.yahoo.com/?To=%s"},{"name":"Gmail","uriTemplate":"https://mail.google.com/mail/?extsrc=mailto&url=%s"}]},"irc":{"action":2,"ask":true,"handlers":[null,{"name":"Mibbit","uriTemplate":"https://www.mibbit.com/?url=%s"}]},"webcal":{"action":2,"ask":true,"handlers":[null,{"name":"30 Boxes","uriTemplate":"https://30boxes.com/external/widget?refer=ff&url=%s"}]},"vlc":{"action":2,"handlers":[{"name":"callvlc","path":"/usr/local/bin/callvlc"}]}}}' > handlers.json
+
+# Create a vlc protocol
+printf '%s\n' 'user_pref("network.protocol-handler.expose.vlc", false);' > user.js


### PR DESCRIPTION
This should make setting up `callvlc` easier. Please review and provide feedback.

Perhaps `jq` should be used for adding what's missing to `handlers.json`, instead of just going with this static file?